### PR TITLE
feat: transaction watcher

### DIFF
--- a/src/components/Counter.tsx
+++ b/src/components/Counter.tsx
@@ -1,17 +1,15 @@
-import { useTonhubConnect } from "react-ton-x";
-import { useQuery } from "@tanstack/react-query";
+
 import { Address, toNano, beginCell } from "ton";
 import { Card } from "./Card";
-import { tc } from "./Ton-Connector";
-import { useState } from "react";
 import { useMakeGetCall } from "../hooks/useMakeGetCall";
 import { useSendTxn } from "../hooks/useSendTxn";
 import BN from "bn.js";
+import { TransactionWatcher } from './TransactionWatcher';
 
 export function Counter() {
   const counterAddr = "EQC-QTihJV_B4f8M2nynateMLynaRT_uwNYnnuyy87kam-G7";
 
-  const { isIssuedTxn, sendTxn, markTxnEnded } = useSendTxn();
+  const { isIssuedTxn, txnState, sendTxn, markTxnEnded } = useSendTxn();
   const { data, isFetching } = useMakeGetCall(
     Address.parse(counterAddr),
     "counter",
@@ -40,6 +38,7 @@ export function Counter() {
       >
         Increment
       </button>
+      <TransactionWatcher txnState={txnState} />
     </Card>
   );
 }

--- a/src/components/TransactionWatcher.tsx
+++ b/src/components/TransactionWatcher.tsx
@@ -1,0 +1,29 @@
+import { useTonhubConnect } from 'react-ton-x';
+import { TxnState } from '../hooks/useSendTxn';
+import { Card } from './Card';
+
+export function TransactionWatcher(props: { txnState: TxnState }) {
+    if (props.txnState === 'idle') {
+        return null;
+    }
+
+    let txStatus = '';
+    if (props.txnState === 'requested') {
+        txStatus = 'Transaction requested';
+    }
+    if (props.txnState === 'pending') {
+        txStatus = 'Transaction pending';
+    }
+    if (props.txnState === 'success') {
+        txStatus = 'Transaction success';
+    }
+    if (props.txnState === 'error') {
+        txStatus = 'Transaction error';
+    }
+
+    return (
+        <Card title="Transaction status">
+            <h3>{txStatus}</h3>
+        </Card>
+    )
+}

--- a/src/hooks/useSendTxn.ts
+++ b/src/hooks/useSendTxn.ts
@@ -2,26 +2,51 @@ import { useState } from "react";
 import { useTonhubConnect } from "react-ton-x";
 import { Address, Cell, toNano } from "ton";
 import BN from "bn.js";
+import { tc } from '../components/Ton-Connector';
+
+export type TxnState = 'idle' | 'requested' | 'pending' | 'success' | 'error';
 
 export function useSendTxn() {
   const connect = useTonhubConnect();
-  const [isIssuedTxn, setIssuedTxn] = useState(false);
+  const [txnState, setTxnState] = useState<TxnState>('idle');
 
   return {
     sendTxn: async (address: Address, value: BN, body: Cell) => {
+      setTxnState('requested');
       const txnStat = await connect.api.requestTransaction({
         to: address.toFriendly(),
         value: value.toString(),
         payload: body.toBoc().toString("base64"),
       });
 
+
       if (txnStat.type === "success") {
-        setIssuedTxn(true);
+        setTxnState('pending');
+        
+        let found = false;
+        let now = Date.now();
+        for (let i = 0; i < 5; i++) {
+          let txns = await tc.getTransactions(address, { limit: 5 });
+          let hasTx = txns.find(tx => tx.inMessage?.value.eq(value) && tx.time * 1000 > now);
+          if (hasTx) {
+            found = true;
+            break;
+          }
+          await new Promise((resolve) => setTimeout(resolve, 6000));
+        }
+        if (found) {
+          setTxnState('success');
+        } else {
+          setTxnState('error');
+        }
+      } else {
+        setTxnState('error');
       }
     },
-    isIssuedTxn,
+    txnState,
+    isIssuedTxn: txnState === 'requested' || txnState === 'pending',
     markTxnEnded: () => {
-      setIssuedTxn(false);
+      setTxnState('idle');
     },
   };
 }


### PR DESCRIPTION
Solves #8 

- Extended `sendTxn` logic to return state of current transaction and watch for it. 
- Added `TransactionWatcher` component consuming state of transaction

Example can be found in `Counter`